### PR TITLE
ON-687: Review Sft Marketplace Access Control

### DIFF
--- a/.openzeppelin/polygon.json
+++ b/.openzeppelin/polygon.json
@@ -1782,6 +1782,188 @@
           }
         }
       }
+    },
+    "77de5d1671caec03712eb3b9a688c3f3184716328a6ac6edf2de6e7fa2341f1d": {
+      "address": "0x382f30C4B4D6c7C6c6008a56709926b56609dB1c",
+      "txHash": "0xc807911267abd38f5b9ed484f6d143c480b600f23133757040be5b94c290b844",
+      "layout": {
+        "solcVersion": "0.8.9",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "oriumMarketplaceRoyalties",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "OriumSftMarketplace",
+            "src": "contracts/OriumSftMarketplace.sol:22"
+          },
+          {
+            "label": "isCreated",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "OriumSftMarketplace",
+            "src": "contracts/OriumSftMarketplace.sol:25"
+          },
+          {
+            "label": "nonceDeadline",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_uint64))",
+            "contract": "OriumSftMarketplace",
+            "src": "contracts/OriumSftMarketplace.sol:28"
+          },
+          {
+            "label": "commitmentIdToNonce",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_uint256))",
+            "contract": "OriumSftMarketplace",
+            "src": "contracts/OriumSftMarketplace.sol:31"
+          },
+          {
+            "label": "rentals",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_mapping(t_bytes32,t_struct(Rental)7733_storage)",
+            "contract": "OriumSftMarketplace",
+            "src": "contracts/OriumSftMarketplace.sol:34"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_uint256))": {
+            "label": "mapping(address => mapping(uint256 => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_uint64))": {
+            "label": "mapping(address => mapping(uint256 => uint64))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(Rental)7733_storage)": {
+            "label": "mapping(bytes32 => struct OriumSftMarketplace.Rental)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint256)": {
+            "label": "mapping(uint256 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint64)": {
+            "label": "mapping(uint256 => uint64)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Rental)7733_storage": {
+            "label": "struct OriumSftMarketplace.Rental",
+            "members": [
+              {
+                "label": "borrower",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "expirationDate",
+                "type": "t_uint64",
+                "offset": 20,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/addresses/polygon/index.json
+++ b/addresses/polygon/index.json
@@ -29,10 +29,10 @@
 	"OriumSftMarketplace": {
 		"address": "0xB1D47B09aa6D81d7B00C3A37705a6A157B83C49F",
 		"operator": "0x359E1208DE02Af11461A37D72165Ef2dcD2Adfc8",
-		"implementation": "0xBCb15E3bA0BdB225099BbBef81B148a0B1d6B72b",
+		"implementation": "0x382f30C4B4D6c7C6c6008a56709926b56609dB1c",
 		"proxyAdmin": "0x48c769f6a8de57d824f0e7330d7A27dee53a43cD",
 		"libraries": [
-			"0xA7c62aDC386c8860Aa538028C8cFF6F286daC9e4"
+			"0x3f480CbeB1e6a3624C3470b0593A428d06E17F02"
 		]
 	}
 }

--- a/contracts/OriumSftMarketplace.sol
+++ b/contracts/OriumSftMarketplace.sol
@@ -254,36 +254,12 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
     }
 
     /**
-     * @notice Releases the tokens of a rental offer.
-     * @dev Can only be called by the lender.
-     * @param _offer The rental offer struct. It should be the same as the one used to create the offer.
-     */
-    function batchReleaseTokens(RentalOffer[] calldata _offer) whenNotPaused external {
-        for (uint256 i = 0; i < _offer.length; i++) {
-            bytes32 _offerHash = LibOriumSftMarketplace.hashRentalOffer(_offer[i]);
-            require(isCreated[_offerHash], "OriumSftMarketplace: Offer not created");
-            require(msg.sender == _offer[i].lender, "OriumSftMarketplace: Only lender can release tokens");
-            require(
-                rentals[_offerHash].expirationDate < block.timestamp,
-                "OriumSftMarketplace: Offer has an active Rental"
-            );
-            require(
-                nonceDeadline[_offer[i].lender][_offer[i].nonce] < block.timestamp,
-                "OriumSftMarketplace: Offer still active"
-            );
-
-            IERC7589(IOriumMarketplaceRoyalties(oriumMarketplaceRoyalties).sftRolesRegistryOf(_offer[i].tokenAddress))
-                .releaseTokens(_offer[i].commitmentId);
-        }
-    }
-
-    /**
      * @notice Releases the tokens in the commitment batch.
      * @dev Can only be called by the commitment's grantor.
      * @param _tokenAddresses The SFT tokenAddresses.
      * @param _commitmentIds The commitmentIds to release.
      */
-    function batchReleaseTokensFromCommitment(
+    function batchReleaseTokens(
         address[] calldata _tokenAddresses,
         uint256[] calldata _commitmentIds
     ) whenNotPaused external {

--- a/contracts/OriumSftMarketplace.sol
+++ b/contracts/OriumSftMarketplace.sol
@@ -118,7 +118,7 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
      * @dev To optimize for gas, only the offer hash is stored on-chain
      * @param _offer The rental offer struct.
      */
-    function createRentalOffer(RentalOffer memory _offer) whenNotPaused external {
+    function createRentalOffer(RentalOffer memory _offer) external whenNotPaused {
         address _rolesRegistryAddress = IOriumMarketplaceRoyalties(oriumMarketplaceRoyalties).sftRolesRegistryOf(
             _offer.tokenAddress
         );
@@ -159,7 +159,7 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
      * @param _offer The rental offer struct. It should be the same as the one used to create the offer.
      * @param _duration The duration of the rental.
      */
-    function acceptRentalOffer(RentalOffer calldata _offer, uint64 _duration) whenNotPaused external {
+    function acceptRentalOffer(RentalOffer calldata _offer, uint64 _duration) external whenNotPaused {
         bytes32 _offerHash = LibOriumSftMarketplace.hashRentalOffer(_offer);
         require(isCreated[_offerHash], "OriumSftMarketplace: Offer not created");
         require(
@@ -203,7 +203,7 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
      * @notice Cancels a rental offer.
      * @param _offer The rental offer struct. It should be the same as the one used to create the offer.
      */
-    function cancelRentalOffer(RentalOffer calldata _offer) whenNotPaused external {
+    function cancelRentalOffer(RentalOffer calldata _offer) external whenNotPaused {
         bytes32 _offerHash = LibOriumSftMarketplace.hashRentalOffer(_offer);
         require(isCreated[_offerHash], "OriumSftMarketplace: Offer not created");
         require(msg.sender == _offer.lender, "OriumSftMarketplace: Only lender can cancel a rental offer");
@@ -229,7 +229,7 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
      * @dev Borrower needs to approve marketplace to revoke the roles.
      * @param _offer The rental offer struct. It should be the same as the one used to create the offer.
      */
-    function endRental(RentalOffer calldata _offer) whenNotPaused external {
+    function endRental(RentalOffer calldata _offer) external whenNotPaused {
         bytes32 _offerHash = LibOriumSftMarketplace.hashRentalOffer(_offer);
 
         require(isCreated[_offerHash], "OriumSftMarketplace: Offer not created");
@@ -262,29 +262,15 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
     function batchReleaseTokens(
         address[] calldata _tokenAddresses,
         uint256[] calldata _commitmentIds
-    ) whenNotPaused external {
-        require(_tokenAddresses.length == _commitmentIds.length, "OriumSftMarketplace: arrays length mismatch");
-        for (uint256 i = 0; i < _tokenAddresses.length; i++) {
-            address _rolesRegistryAddress = IOriumMarketplaceRoyalties(oriumMarketplaceRoyalties).sftRolesRegistryOf(
-                _tokenAddresses[i]
-            );
-            require(
-                IERC7589(_rolesRegistryAddress).grantorOf(_commitmentIds[i]) == msg.sender,
-                "OriumSftMarketplace: sender is not the commitment's grantor"
-            );
-            require(
-                IERC7589(_rolesRegistryAddress).tokenAddressOf(_commitmentIds[i]) == _tokenAddresses[i],
-                "OriumSftMarketplace: tokenAddress provided does not match commitment's tokenAddress"
-            );
-            IERC7589(_rolesRegistryAddress).releaseTokens(_commitmentIds[i]);
-        }
+    ) external whenNotPaused {
+        LibOriumSftMarketplace.batchReleaseTokens(oriumMarketplaceRoyalties, _tokenAddresses, _commitmentIds);
     }
 
     /**
      * @notice batchCommitTokensAndGrantRole commits tokens and grant role in a single transaction.
      * @param _params The array of CommitAndGrantRoleParams.
      */
-    function batchCommitTokensAndGrantRole(CommitAndGrantRoleParams[] calldata _params) whenNotPaused external {
+    function batchCommitTokensAndGrantRole(CommitAndGrantRoleParams[] calldata _params) external whenNotPaused {
         for (uint256 i = 0; i < _params.length; i++) {
             address _rolesRegistryAddress = IOriumMarketplaceRoyalties(oriumMarketplaceRoyalties).sftRolesRegistryOf(
                 _params[i].tokenAddress
@@ -336,7 +322,7 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
         bytes32[] memory _roles,
         address[] memory _grantees,
         address[] memory _tokenAddresses
-    ) whenNotPaused external {
+    ) external whenNotPaused {
         require(
             _commitmentIds.length == _roles.length &&
                 _commitmentIds.length == _grantees.length &&

--- a/contracts/OriumSftMarketplace.sol
+++ b/contracts/OriumSftMarketplace.sol
@@ -16,8 +16,6 @@ import { IOriumMarketplaceRoyalties } from "./interfaces/IOriumMarketplaceRoyalt
  * @author Orium Network Team - developers@orium.network
  */
 contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgradeable {
-    /** ######### Constants ########### **/
-
     /** ######### Global Variables ########### **/
 
     /// @dev oriumMarketplaceRoyalties stores the collection royalties and fees
@@ -161,22 +159,23 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
      * @param _offer The rental offer struct. It should be the same as the one used to create the offer.
      * @param _duration The duration of the rental.
      */
-    function acceptRentalOffer(RentalOffer calldata _offer, uint64 _duration) external {
-        uint64 _expirationDate = uint64(block.timestamp + _duration);
+    function acceptRentalOffer(RentalOffer calldata _offer, uint64 _duration) external whenNotPaused {
         bytes32 _offerHash = LibOriumSftMarketplace.hashRentalOffer(_offer);
-
+        require(isCreated[_offerHash], "OriumSftMarketplace: Offer not created");
         require(
             rentals[_offerHash].expirationDate <= block.timestamp,
             "OriumSftMarketplace: This offer has an ongoing rental"
         );
-        require(isCreated[_offerHash], "OriumSftMarketplace: Offer not created");
-        require(
-            address(0) == _offer.borrower || msg.sender == _offer.borrower,
-            "OriumSftMarketplace: Sender is not allowed to rent this SFT"
-        );
+
+        uint64 _expirationDate = uint64(block.timestamp + _duration);
         require(
             nonceDeadline[_offer.lender][_offer.nonce] > _expirationDate,
             "OriumSftMarketplace: expiration date is greater than offer deadline"
+        );
+
+        require(
+            address(0) == _offer.borrower || msg.sender == _offer.borrower,
+            "OriumSftMarketplace: Sender is not allowed to rent this SFT"
         );
 
         _transferFees(_offer.tokenAddress, _offer.feeTokenAddress, _offer.feeAmountPerSecond, _duration, _offer.lender);
@@ -204,7 +203,7 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
      * @notice Cancels a rental offer.
      * @param _offer The rental offer struct. It should be the same as the one used to create the offer.
      */
-    function cancelRentalOffer(RentalOffer calldata _offer) external {
+    function cancelRentalOffer(RentalOffer calldata _offer) external whenNotPaused {
         bytes32 _offerHash = LibOriumSftMarketplace.hashRentalOffer(_offer);
         require(isCreated[_offerHash], "OriumSftMarketplace: Offer not created");
         require(msg.sender == _offer.lender, "OriumSftMarketplace: Only lender can cancel a rental offer");
@@ -213,7 +212,8 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
             "OriumSftMarketplace: Nonce expired or not used yet"
         );
 
-        // if There are no active Rentals, release tokens (else, tokens will be released via `batchReleaseTokens`)
+        // if There are no active rentals, release tokens (else, tokens will be released via `batchReleaseTokens`)
+        // this is ok for single-role tokens, but tokens with multiple roles might revert if another non-revocable role exists
         if (rentals[_offerHash].expirationDate < block.timestamp) {
             IERC7589(IOriumMarketplaceRoyalties(oriumMarketplaceRoyalties).sftRolesRegistryOf(_offer.tokenAddress))
                 .releaseTokens(_offer.commitmentId);
@@ -224,12 +224,12 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
     }
 
     /**
-     * @notice Ends the rental.
+     * @notice Ends the rental prematurely.
      * @dev Can only be called by the borrower.
      * @dev Borrower needs to approve marketplace to revoke the roles.
      * @param _offer The rental offer struct. It should be the same as the one used to create the offer.
      */
-    function endRental(RentalOffer memory _offer) external {
+    function endRental(RentalOffer calldata _offer) external whenNotPaused {
         bytes32 _offerHash = LibOriumSftMarketplace.hashRentalOffer(_offer);
 
         require(isCreated[_offerHash], "OriumSftMarketplace: Offer not created");
@@ -281,12 +281,13 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
      * @notice batchCommitTokensAndGrantRole commits tokens and grant role in a single transaction.
      * @param _params The array of CommitAndGrantRoleParams.
      */
-    function batchCommitTokensAndGrantRole(CommitAndGrantRoleParams[] calldata _params) external {
+    function batchCommitTokensAndGrantRole(CommitAndGrantRoleParams[] calldata _params) external whenNotPaused {
         for (uint256 i = 0; i < _params.length; i++) {
-            IERC7589 _rolesRegistry = IERC7589(
-                IOriumMarketplaceRoyalties(oriumMarketplaceRoyalties).sftRolesRegistryOf(_params[i].tokenAddress)
+            address _rolesRegistryAddress = IOriumMarketplaceRoyalties(oriumMarketplaceRoyalties).sftRolesRegistryOf(
+                _params[i].tokenAddress
             );
 
+            IERC7589 _rolesRegistry = IERC7589(_rolesRegistryAddress);
             uint256 _validCommitmentId = _params[i].commitmentId;
             if (_params[i].commitmentId == 0) {
                 _validCommitmentId = _rolesRegistry.commitTokens(
@@ -294,6 +295,17 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
                     _params[i].tokenAddress,
                     _params[i].tokenId,
                     _params[i].tokenAmount
+                );
+            } else {
+                // if the user provided a valid commitmentId, it's necessary to verify if they actually own it,
+                // and if all other parameters passed match the commitmentId
+                LibOriumSftMarketplace.validateCommitmentId(
+                    _params[i].commitmentId,
+                    _params[i].tokenAddress,
+                    _params[i].tokenId,
+                    _params[i].tokenAmount,
+                    msg.sender,
+                    _rolesRegistryAddress
                 );
             }
 
@@ -321,7 +333,7 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
         bytes32[] memory _roles,
         address[] memory _grantees,
         address[] memory _tokenAddresses
-    ) external {
+    ) external whenNotPaused {
         require(
             _commitmentIds.length == _roles.length &&
                 _commitmentIds.length == _grantees.length &&
@@ -330,12 +342,22 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
         );
 
         for (uint256 i = 0; i < _commitmentIds.length; i++) {
-            IERC7589(IOriumMarketplaceRoyalties(oriumMarketplaceRoyalties).sftRolesRegistryOf(_tokenAddresses[i]))
-                .revokeRole(_commitmentIds[i], _roles[i], _grantees[i]);
+            address _rolesRegistryAddress = IOriumMarketplaceRoyalties(oriumMarketplaceRoyalties).sftRolesRegistryOf(
+                _tokenAddresses[i]
+            );
+
+            require(
+                IERC7589(_rolesRegistryAddress).grantorOf(_commitmentIds[i]) == msg.sender,
+                "OriumSftMarketplace: sender is not the commitment's grantor"
+            );
+            require(
+                IERC7589(_rolesRegistryAddress).tokenAddressOf(_commitmentIds[i]) == _tokenAddresses[i],
+                "OriumSftMarketplace: tokenAddress provided does not match commitment's tokenAddress"
+            );
+
+            IERC7589(_rolesRegistryAddress).revokeRole(_commitmentIds[i], _roles[i], _grantees[i]);
         }
     }
-
-    /** ######### Getters ########### **/
 
     /** ######### Internals ########### **/
     /**

--- a/contracts/OriumSftMarketplace.sol
+++ b/contracts/OriumSftMarketplace.sol
@@ -118,7 +118,7 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
      * @dev To optimize for gas, only the offer hash is stored on-chain
      * @param _offer The rental offer struct.
      */
-    function createRentalOffer(RentalOffer memory _offer) external whenNotPaused {
+    function createRentalOffer(RentalOffer memory _offer) whenNotPaused external {
         address _rolesRegistryAddress = IOriumMarketplaceRoyalties(oriumMarketplaceRoyalties).sftRolesRegistryOf(
             _offer.tokenAddress
         );
@@ -159,7 +159,7 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
      * @param _offer The rental offer struct. It should be the same as the one used to create the offer.
      * @param _duration The duration of the rental.
      */
-    function acceptRentalOffer(RentalOffer calldata _offer, uint64 _duration) external whenNotPaused {
+    function acceptRentalOffer(RentalOffer calldata _offer, uint64 _duration) whenNotPaused external {
         bytes32 _offerHash = LibOriumSftMarketplace.hashRentalOffer(_offer);
         require(isCreated[_offerHash], "OriumSftMarketplace: Offer not created");
         require(
@@ -203,7 +203,7 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
      * @notice Cancels a rental offer.
      * @param _offer The rental offer struct. It should be the same as the one used to create the offer.
      */
-    function cancelRentalOffer(RentalOffer calldata _offer) external whenNotPaused {
+    function cancelRentalOffer(RentalOffer calldata _offer) whenNotPaused external {
         bytes32 _offerHash = LibOriumSftMarketplace.hashRentalOffer(_offer);
         require(isCreated[_offerHash], "OriumSftMarketplace: Offer not created");
         require(msg.sender == _offer.lender, "OriumSftMarketplace: Only lender can cancel a rental offer");
@@ -229,7 +229,7 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
      * @dev Borrower needs to approve marketplace to revoke the roles.
      * @param _offer The rental offer struct. It should be the same as the one used to create the offer.
      */
-    function endRental(RentalOffer calldata _offer) external whenNotPaused {
+    function endRental(RentalOffer calldata _offer) whenNotPaused external {
         bytes32 _offerHash = LibOriumSftMarketplace.hashRentalOffer(_offer);
 
         require(isCreated[_offerHash], "OriumSftMarketplace: Offer not created");
@@ -258,7 +258,7 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
      * @dev Can only be called by the lender.
      * @param _offer The rental offer struct. It should be the same as the one used to create the offer.
      */
-    function batchReleaseTokens(RentalOffer[] calldata _offer) external whenNotPaused {
+    function batchReleaseTokens(RentalOffer[] calldata _offer) whenNotPaused external {
         for (uint256 i = 0; i < _offer.length; i++) {
             bytes32 _offerHash = LibOriumSftMarketplace.hashRentalOffer(_offer[i]);
             require(isCreated[_offerHash], "OriumSftMarketplace: Offer not created");
@@ -286,7 +286,7 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
     function batchReleaseTokensFromCommitment(
         address[] calldata _tokenAddresses,
         uint256[] calldata _commitmentIds
-    ) external whenNotPaused {
+    ) whenNotPaused external {
         require(_tokenAddresses.length == _commitmentIds.length, "OriumSftMarketplace: arrays length mismatch");
         for (uint256 i = 0; i < _tokenAddresses.length; i++) {
             address _rolesRegistryAddress = IOriumMarketplaceRoyalties(oriumMarketplaceRoyalties).sftRolesRegistryOf(
@@ -308,7 +308,7 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
      * @notice batchCommitTokensAndGrantRole commits tokens and grant role in a single transaction.
      * @param _params The array of CommitAndGrantRoleParams.
      */
-    function batchCommitTokensAndGrantRole(CommitAndGrantRoleParams[] calldata _params) external whenNotPaused {
+    function batchCommitTokensAndGrantRole(CommitAndGrantRoleParams[] calldata _params) whenNotPaused external {
         for (uint256 i = 0; i < _params.length; i++) {
             address _rolesRegistryAddress = IOriumMarketplaceRoyalties(oriumMarketplaceRoyalties).sftRolesRegistryOf(
                 _params[i].tokenAddress
@@ -360,7 +360,7 @@ contract OriumSftMarketplace is Initializable, OwnableUpgradeable, PausableUpgra
         bytes32[] memory _roles,
         address[] memory _grantees,
         address[] memory _tokenAddresses
-    ) external whenNotPaused {
+    ) whenNotPaused external {
         require(
             _commitmentIds.length == _roles.length &&
                 _commitmentIds.length == _grantees.length &&

--- a/contracts/libraries/LibOriumSftMarketplace.sol
+++ b/contracts/libraries/LibOriumSftMarketplace.sol
@@ -79,7 +79,7 @@ library LibOriumSftMarketplace {
      * @param _tokenAddress The token address.
      * @param _tokenId The token id.
      * @param _tokenAmount The token amount.
-     * @param _lender The lender address.
+     * @param _expectedGrantor The expected grantor.
      * @param _rolesRegistryAddress The roles registry address.
      */
     function validateCommitmentId(
@@ -87,26 +87,25 @@ library LibOriumSftMarketplace {
         address _tokenAddress,
         uint256 _tokenId,
         uint256 _tokenAmount,
-        address _lender,
+        address _expectedGrantor,
         address _rolesRegistryAddress
     ) external view {
         IERC7589 _rolesRegistry = IERC7589(_rolesRegistryAddress);
         require(
             _rolesRegistry.tokenAmountOf(_commitmentId) == _tokenAmount,
-            "OriumSftMarketplace: commitmentId token amount does not match offer's token amount"
+            "OriumSftMarketplace: tokenAmount provided does not match commitment's tokenAmount"
         );
-
         require(
-            _rolesRegistry.grantorOf(_commitmentId) == _lender,
-            "OriumSftMarketplace: commitmentId grantor does not match offer's lender"
+            _rolesRegistry.grantorOf(_commitmentId) == _expectedGrantor,
+            "OriumSftMarketplace: expected grantor does not match the grantor of the commitmentId"
         );
         require(
             _rolesRegistry.tokenAddressOf(_commitmentId) == _tokenAddress,
-            "OriumSftMarketplace: commitmentId tokenAddress does not match offer's tokenAddress"
+            "OriumSftMarketplace: tokenAddress provided does not match commitment's tokenAddress"
         );
         require(
             _rolesRegistry.tokenIdOf(_commitmentId) == _tokenId,
-            "OriumSftMarketplace: commitmentId tokenId does not match offer's tokenId"
+            "OriumSftMarketplace: tokenId provided does not match commitment's tokenId"
         );
     }
 

--- a/contracts/libraries/LibOriumSftMarketplace.sol
+++ b/contracts/libraries/LibOriumSftMarketplace.sol
@@ -3,6 +3,7 @@
 pragma solidity 0.8.9;
 
 import { IERC7589 } from "../interfaces/IERC7589.sol";
+import { IOriumMarketplaceRoyalties } from "../interfaces/IOriumMarketplaceRoyalties.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /// @dev Rental offer info.
@@ -166,5 +167,33 @@ library LibOriumSftMarketplace {
             IERC20(_feeTokenAddress).transferFrom(msg.sender, _lenderAddress, _lenderAmount),
             "OriumSftMarketplace: Transfer failed"
         );
+    }
+
+    /**
+     * @notice Releases the tokens in the commitment batch.
+     * @dev Can only be called by the commitment's grantor.
+     * @param _oriumMarketplaceRoyaltiesAddress The address of the OriumMarketplaceRoyalties contract.
+     * @param _tokenAddresses The SFT tokenAddresses.
+     * @param _commitmentIds The commitmentIds to release.
+     */
+    function batchReleaseTokens(
+        address _oriumMarketplaceRoyaltiesAddress,
+        address[] calldata _tokenAddresses,
+        uint256[] calldata _commitmentIds
+    ) external {
+        require(_tokenAddresses.length == _commitmentIds.length, "OriumSftMarketplace: arrays length mismatch");
+        for (uint256 i = 0; i < _tokenAddresses.length; i++) {
+            address _rolesRegistryAddress = IOriumMarketplaceRoyalties(_oriumMarketplaceRoyaltiesAddress)
+                .sftRolesRegistryOf(_tokenAddresses[i]);
+            require(
+                IERC7589(_rolesRegistryAddress).grantorOf(_commitmentIds[i]) == msg.sender,
+                "OriumSftMarketplace: sender is not the commitment's grantor"
+            );
+            require(
+                IERC7589(_rolesRegistryAddress).tokenAddressOf(_commitmentIds[i]) == _tokenAddresses[i],
+                "OriumSftMarketplace: tokenAddress provided does not match commitment's tokenAddress"
+            );
+            IERC7589(_rolesRegistryAddress).releaseTokens(_commitmentIds[i]);
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "contract-size": "npx hardhat size-contracts",
     "deploy:mumbai": "npx hardhat run --network mumbai scripts/01-deploy.ts",
     "deploy:polygon": "npx hardhat run --network polygon scripts/01-deploy.ts",
-    "create-offer:polygon": "npx hardhat run scripts/orium-sft-marketplace/02-create-offer.ts --network polygon",
-    "cancel-offer:polygon": "npx hardhat run scripts/orium-sft-marketplace/03-cancel-offer.ts --network polygon",
-    "propose-upgrade:polygon": "npx hardhat run scripts/orium-sft-marketplace/06-propose-upgrade.ts --network polygon"
+    "create-offer:orium-sft-marketplace:polygon": "npx hardhat run scripts/orium-sft-marketplace/02-create-offer.ts --network polygon",
+    "cancel-offer:orium-sft-marketplace:polygon": "npx hardhat run scripts/orium-sft-marketplace/03-cancel-offer.ts --network polygon",
+    "propose-upgrade:orium-sft-marketplace:polygon": "npx hardhat run scripts/orium-sft-marketplace/06-propose-upgrade.ts --network polygon"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,12 @@
     "lint": "npx eslint .",
     "lint:staged": "npx lint-staged",
     "lint:fix": "npx eslint . --fix && npx prettier --write .",
+    "contract-size": "npx hardhat size-contracts",
     "deploy:mumbai": "npx hardhat run --network mumbai scripts/01-deploy.ts",
-    "deploy:polygon": "npx hardhat run --network polygon scripts/01-deploy.ts"
+    "deploy:polygon": "npx hardhat run --network polygon scripts/01-deploy.ts",
+    "create-offer:polygon": "npx hardhat run scripts/orium-sft-marketplace/02-create-offer.ts --network polygon",
+    "cancel-offer:polygon": "npx hardhat run scripts/orium-sft-marketplace/03-cancel-offer.ts --network polygon",
+    "propose-upgrade:polygon": "npx hardhat run scripts/orium-sft-marketplace/06-propose-upgrade.ts --network polygon"
   },
   "husky": {
     "hooks": {

--- a/scripts/orium-marketplace/data/metadata.ts
+++ b/scripts/orium-marketplace/data/metadata.ts
@@ -1,7 +1,7 @@
-import { toWei } from '../../utils/bignumber'
+import { toWei } from '../../../utils/bignumber'
 import { defaultAbiCoder as abi } from 'ethers/lib/utils'
-import { USER_ROLE } from '../../utils/roles'
-import { inputsToTypes } from '../../utils/role-metadata'
+import { USER_ROLE } from '../../../utils/roles'
+import { inputsToTypes } from '../../../utils/role-metadata'
 
 export const role1 = '0x3d926b0dd5f4880fb18c9a49c890c7d76c2a97e0d4b4c20f1bb3fe6e5f89f5f4'
 export const roleMetadata1 = {

--- a/scripts/orium-sft-marketplace/02-create-offer.ts
+++ b/scripts/orium-sft-marketplace/02-create-offer.ts
@@ -6,6 +6,7 @@ import { AddressZero, ONE_DAY } from '../../utils/constants'
 import { randomBytes } from 'crypto'
 import { BigNumber } from 'ethers'
 import { UNIQUE_ROLE } from '../../utils/roles'
+import { etherPerDayToWeiPerSecond } from '../../utils/bignumber'
 
 async function main() {
   const NETWORK = hardhatNetwork.name as Network
@@ -29,12 +30,12 @@ async function main() {
      * 252 - helmet
      * 350 - t-shirt
      */
-    tokenId: 350,
+    tokenId: 253,
     tokenAmount: BigNumber.from('1'),
     commitmentId: BigNumber.from('0'),
     feeTokenAddress: '0x385Eeac5cB85A38A9a07A70c73e0a3271CfB54A7', // GHST address
-    feeAmountPerSecond: BigNumber.from('1'),
-    deadline: blockTimestamp + ONE_DAY * 60,
+    feeAmountPerSecond: etherPerDayToWeiPerSecond('5.2'),
+    deadline: blockTimestamp + ONE_DAY * 9,
     roles: [UNIQUE_ROLE],
     rolesData: ['0x'],
   }

--- a/scripts/orium-sft-marketplace/02-create-offer.ts
+++ b/scripts/orium-sft-marketplace/02-create-offer.ts
@@ -5,17 +5,13 @@ import { SftRentalOffer } from '../../utils/types'
 import { AddressZero, ONE_DAY } from '../../utils/constants'
 import { randomBytes } from 'crypto'
 import { BigNumber } from 'ethers'
-import { UNIQUE_ROLE } from '../../utils/roles'
+import { PLAYER_ROLE } from '../../utils/roles'
 import { etherPerDayToWeiPerSecond } from '../../utils/bignumber'
 
 async function main() {
   const NETWORK = hardhatNetwork.name as Network
   const CONTRACT_NAME = 'OriumSftMarketplace'
   const CONTRACT_ADDRESS = config[NETWORK][CONTRACT_NAME].address
-
-  await confirmOrDie(
-    `Are you sure you want to create a rental offer ${config[NETWORK].OriumSftMarketplace.address} for ${CONTRACT_NAME} on ${NETWORK} network?`,
-  )
 
   const contract = await ethers.getContractAt(CONTRACT_NAME, CONTRACT_ADDRESS)
 
@@ -24,26 +20,28 @@ async function main() {
   const rentalOffer: SftRentalOffer = {
     nonce: BigNumber.from(`0x${randomBytes(32).toString('hex')}`).toString(),
     lender: '0xe3A75c99cD21674188bea652Fe378cA5cf7e7906', // dev wallet
-    borrower: AddressZero,
+    borrower: AddressZero, // 0x31A14626579c3197B43DE563128c2171F4F840aD
     tokenAddress: '0x58de9AaBCaeEC0f69883C94318810ad79Cc6a44f', // wearables
-    /**
-     * 252 - helmet
-     * 350 - t-shirt
-     */
-    tokenId: 253,
-    tokenAmount: BigNumber.from('1'),
-    commitmentId: BigNumber.from('0'),
     feeTokenAddress: '0x385Eeac5cB85A38A9a07A70c73e0a3271CfB54A7', // GHST address
-    feeAmountPerSecond: etherPerDayToWeiPerSecond('5.2'),
-    deadline: blockTimestamp + ONE_DAY * 9,
-    roles: [UNIQUE_ROLE],
+    roles: [PLAYER_ROLE],
     rolesData: ['0x'],
-  }
+    commitmentId: BigNumber.from('0'),
 
-  const tx = await contract.createRentalOffer(rentalOffer)
+    // parameters to update
+    tokenAmount: BigNumber.from('1'),
+    tokenId: 137,
+    feeAmountPerSecond: etherPerDayToWeiPerSecond('0.173'),
+    deadline: blockTimestamp + ONE_DAY * 19,
+  }
 
   console.log('rentalOffer', rentalOffer)
   console.log(`offerId: ${rentalOffer.lender.toLowerCase()}-${BigNumber.from(rentalOffer.nonce).toString()}`)
+
+  await confirmOrDie(
+    `Are you sure you want to create a rental offer ${config[NETWORK].OriumSftMarketplace.address} for ${CONTRACT_NAME} on ${NETWORK} network?`,
+  )
+
+  const tx = await contract.createRentalOffer(rentalOffer, { gasPrice: 50 * 1e9 })
 
   print(colors.highlight, `Transaction hash: ${tx.hash}`)
   print(colors.success, `Created rental offer in ${CONTRACT_NAME} on ${NETWORK} network!`)

--- a/scripts/orium-sft-marketplace/03-cancel-offer.ts
+++ b/scripts/orium-sft-marketplace/03-cancel-offer.ts
@@ -1,38 +1,92 @@
 import { ethers, network as hardhatNetwork } from 'hardhat'
 import config, { Network } from '../../addresses'
 import { colors, print, confirmOrDie } from '../../utils/misc'
-import { BigNumber } from 'ethers'
 import { SftRentalOffer } from '../../utils/types'
-import { UNIQUE_ROLE } from '../../utils/roles'
+import { AddressZero } from '../../utils/constants'
+
+const SubgraphUrl =
+  'https://subgraph.satsuma-prod.com/83d01390f7d3/8c268d3e8b83112a7d0c732a9b88ba1c732da600bffaf68790171b9a0b5d5394/polygon-mainnet_orium-rental-marketplace/api'
+const RentalOfferId =
+  '0xb1d47b09aa6d81d7b00c3a37705a6a157b83c49f-0xe3a75c99cd21674188bea652fe378ca5cf7e7906-88503925159079469072461611536684263787861271681407587493144538997301870344226'
 
 async function main() {
   const NETWORK = hardhatNetwork.name as Network
   const CONTRACT_NAME = 'OriumSftMarketplace'
   const CONTRACT_ADDRESS = config[NETWORK][CONTRACT_NAME].address
 
+  const rentalOffer = await fetchRentalOffer(RentalOfferId)
+  console.log('Rental offer:', rentalOffer)
+
   await confirmOrDie(`Are you sure you want to cancel a rental offer in ${CONTRACT_NAME} on ${NETWORK} network?`)
 
   const contract = await ethers.getContractAt(CONTRACT_NAME, CONTRACT_ADDRESS)
-
-  const rentalOffer: SftRentalOffer = {
-    nonce: '5928844861723570350162087238045846869618317702381369314165749520973527938609',
-    lender: '0xe3A75c99cD21674188bea652Fe378cA5cf7e7906', // dev wallet
-    borrower: '0x596aa1f9EF171075860dFf6062Fe2009991B2323',
-    tokenAddress: '0x58de9AaBCaeEC0f69883C94318810ad79Cc6a44f', // wearables
-    tokenId: 350,
-    tokenAmount: BigNumber.from('1'),
-    commitmentId: BigNumber.from('7'),
-    feeTokenAddress: '0x385Eeac5cB85A38A9a07A70c73e0a3271CfB54A7', // GHST address
-    feeAmountPerSecond: BigNumber.from('1'),
-    deadline: 1712092456,
-    roles: [UNIQUE_ROLE],
-    rolesData: ['0x'],
-  }
-
   const tx = await contract.cancelRentalOffer(rentalOffer)
 
   print(colors.highlight, `Transaction hash: ${tx.hash}`)
   print(colors.success, `Cancelled rental offer in ${CONTRACT_NAME} on ${NETWORK} network!`)
+}
+
+async function fetchRentalOffer(rentalOfferId: string): Promise<SftRentalOffer> {
+  const query = `
+    {
+      rentalOffer(id: "${rentalOfferId}") {
+        nonce
+        lender {
+          id
+        }
+        borrower {
+          id
+        }
+        nft {
+          tokenAddress
+          tokenId
+        }
+        tokenAmount
+        tokenCommitment {
+          commitmentId
+        }
+        feeTokenAddress
+        feeAmountPerSecond
+        deadline
+        isCancelled
+        roles {
+          roleHash
+        }
+        rolesData
+      }
+    }
+  `
+
+  const response = await fetch(SubgraphUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query }),
+  })
+
+  const { data, errors } = await response.json()
+  if (errors) {
+    throw new Error(JSON.stringify(errors, null, 2))
+  }
+
+  // console.log('Rental offer:', data)
+  if (data.rentalOffer.isCancelled) {
+    throw new Error('Rental offer is already cancelled')
+  }
+
+  return {
+    nonce: data.rentalOffer.nonce,
+    lender: data.rentalOffer.lender.id,
+    borrower: data.rentalOffer.borrower?.id.toLowerCase() || AddressZero,
+    tokenAddress: data.rentalOffer.nft.tokenAddress,
+    tokenId: data.rentalOffer.nft.tokenId,
+    tokenAmount: data.rentalOffer.tokenAmount,
+    commitmentId: data.rentalOffer.tokenCommitment.commitmentId,
+    feeTokenAddress: data.rentalOffer.feeTokenAddress,
+    feeAmountPerSecond: data.rentalOffer.feeAmountPerSecond,
+    deadline: data.rentalOffer.deadline,
+    roles: data.rentalOffer.roles.map((role: { roleHash: string }) => role.roleHash),
+    rolesData: data.rentalOffer.rolesData,
+  }
 }
 
 main()

--- a/scripts/orium-sft-marketplace/03-cancel-offer.ts
+++ b/scripts/orium-sft-marketplace/03-cancel-offer.ts
@@ -7,7 +7,7 @@ import { AddressZero } from '../../utils/constants'
 const SubgraphUrl =
   'https://subgraph.satsuma-prod.com/83d01390f7d3/8c268d3e8b83112a7d0c732a9b88ba1c732da600bffaf68790171b9a0b5d5394/polygon-mainnet_orium-rental-marketplace/api'
 const RentalOfferId =
-  '0xb1d47b09aa6d81d7b00c3a37705a6a157b83c49f-0xe3a75c99cd21674188bea652fe378ca5cf7e7906-88503925159079469072461611536684263787861271681407587493144538997301870344226'
+  '0xb1d47b09aa6d81d7b00c3a37705a6a157b83c49f-0xe3a75c99cd21674188bea652fe378ca5cf7e7906-14344696136470398584960849697232759012848660868945066915928195870336883158802'
 
 async function main() {
   const NETWORK = hardhatNetwork.name as Network
@@ -20,7 +20,7 @@ async function main() {
   await confirmOrDie(`Are you sure you want to cancel a rental offer in ${CONTRACT_NAME} on ${NETWORK} network?`)
 
   const contract = await ethers.getContractAt(CONTRACT_NAME, CONTRACT_ADDRESS)
-  const tx = await contract.cancelRentalOffer(rentalOffer)
+  const tx = await contract.cancelRentalOffer(rentalOffer, { gasPrice: 50 * 1e9 })
 
   print(colors.highlight, `Transaction hash: ${tx.hash}`)
   print(colors.success, `Cancelled rental offer in ${CONTRACT_NAME} on ${NETWORK} network!`)

--- a/test/OriumSftMarketplace.test.ts
+++ b/test/OriumSftMarketplace.test.ts
@@ -307,7 +307,7 @@ describe('OriumSftMarketplace', () => {
                   .commitTokens(creator.address, rentalOffer.tokenAddress, rentalOffer.tokenId, rentalOffer.tokenAmount)
                 rentalOffer.commitmentId = BigNumber.from(2)
                 await expect(marketplace.connect(lender).createRentalOffer(rentalOffer)).to.be.revertedWith(
-                  "OriumSftMarketplace: commitmentId grantor does not match offer's lender",
+                  'OriumSftMarketplace: expected grantor does not match the grantor of the commitmentId',
                 )
               })
               it('Should NOT create a rental offer if commitmentId token address and offer token address are different', async () => {
@@ -323,7 +323,7 @@ describe('OriumSftMarketplace', () => {
 
                 rentalOffer.tokenAddress = anotherMockERC1155.address
                 await expect(marketplace.connect(lender).createRentalOffer(rentalOffer)).to.be.revertedWith(
-                  "OriumSftMarketplace: commitmentId tokenAddress does not match offer's tokenAddress",
+                  "OriumSftMarketplace: tokenAddress provided does not match commitment's tokenAddress",
                 )
               })
               it('Should NOT create a rental offer if commitmentId token id and offer token id are different', async () => {
@@ -335,14 +335,14 @@ describe('OriumSftMarketplace', () => {
                   .commitTokens(lender.address, rentalOffer.tokenAddress, newTokenId, rentalOffer.tokenAmount)
                 rentalOffer.commitmentId = BigNumber.from(2)
                 await expect(marketplace.connect(lender).createRentalOffer(rentalOffer)).to.be.revertedWith(
-                  "OriumSftMarketplace: commitmentId tokenId does not match offer's tokenId",
+                  "OriumSftMarketplace: tokenId provided does not match commitment's tokenId",
                 )
               })
               it('Should NOT create a rental offer if commitmentId token amount and offer token amount are different', async () => {
                 rentalOffer.commitmentId = BigNumber.from(2)
                 rentalOffer.tokenAmount = BigNumber.from(3)
                 await expect(marketplace.connect(lender).createRentalOffer(rentalOffer)).to.be.revertedWith(
-                  "OriumSftMarketplace: commitmentId token amount does not match offer's token amount",
+                  "OriumSftMarketplace: tokenAmount provided does not match commitment's tokenAmount",
                 )
               })
             })
@@ -413,6 +413,12 @@ describe('OriumSftMarketplace', () => {
               await expect(marketplace.connect(notOperator).acceptRentalOffer(rentalOffer, duration))
                 .to.emit(marketplace, 'RentalStarted')
                 .withArgs(rentalOffer.lender, rentalOffer.nonce, notOperator.address, blockTimestamp + duration + 3)
+            })
+            it('Should NOT accept a rental offer if contract is paused', async () => {
+              await marketplace.connect(operator).pause()
+              await expect(marketplace.connect(borrower).acceptRentalOffer(rentalOffer, duration)).to.be.revertedWith(
+                'Pausable: paused',
+              )
             })
             it('Should NOT accept a rental offer if caller is not the borrower', async () => {
               rentalOffer.nonce = `0x${randomBytes(32).toString('hex')}`
@@ -525,13 +531,19 @@ describe('OriumSftMarketplace', () => {
                 .to.emit(rolesRegistry, 'TokensReleased')
                 .withArgs(rentalOffer.commitmentId)
             })
+            it('Should NOT cancel a rental offer if contract is paused', async () => {
+              await marketplace.connect(operator).pause()
+              await expect(marketplace.connect(borrower).cancelRentalOffer(rentalOffer)).to.be.revertedWith(
+                'Pausable: paused',
+              )
+            })
             it('Should NOT cancel a rental offer if nonce not used yet by caller', async () => {
               await expect(marketplace.connect(notOperator).cancelRentalOffer(rentalOffer)).to.be.revertedWith(
                 'OriumSftMarketplace: Only lender can cancel a rental offer',
               )
             })
             it("Should NOT cancel a rental offer after deadline's expiration", async () => {
-              // move foward in time to expire the offer
+              // move forward in time to expire the offer
               const blockTimestamp = (await ethers.provider.getBlock('latest')).timestamp
               const timeToMove = rentalOffer.deadline - blockTimestamp + 1
               await ethers.provider.send('evm_increaseTime', [timeToMove])
@@ -593,6 +605,10 @@ describe('OriumSftMarketplace', () => {
                 await expect(marketplace.connect(borrower).endRental(rentalOffer))
                   .to.emit(marketplace, 'RentalEnded')
                   .withArgs(rentalOffer.lender, rentalOffer.nonce)
+              })
+              it('Should NOT end a rental if contract is paused', async () => {
+                await marketplace.connect(operator).pause()
+                await expect(marketplace.connect(lender).endRental(rentalOffer)).to.be.revertedWith('Pausable: paused')
               })
               it('Should NOT end a rental by the lender', async () => {
                 await expect(marketplace.connect(lender).endRental(rentalOffer)).to.be.revertedWith(
@@ -725,6 +741,51 @@ describe('OriumSftMarketplace', () => {
                   commitAndGrantRoleParams[0].data,
                 )
             })
+            it('Should NOT commit tokens and grant role if contract is paused', async () => {
+              await marketplace.connect(operator).pause()
+              await expect(
+                marketplace.connect(lender).batchCommitTokensAndGrantRole(commitAndGrantRoleParams),
+              ).to.be.revertedWith('Pausable: paused')
+            })
+            it('Should NOT commit tokens and grant role if caller is not the grantor of the commitmentId', async () => {
+              commitAndGrantRoleParams[0].commitmentId = BigNumber.from(1)
+              await rolesRegistry
+                .connect(lender)
+                .commitTokens(lender.address, mockERC1155.address, tokenId, tokenAmount)
+              await expect(
+                marketplace.connect(borrower).batchCommitTokensAndGrantRole(commitAndGrantRoleParams),
+              ).to.revertedWith('OriumSftMarketplace: expected grantor does not match the grantor of the commitmentId')
+            })
+            it('Should NOT commit tokens and grant role if tokenAddress does not match the commitment', async () => {
+              commitAndGrantRoleParams[0].commitmentId = BigNumber.from(1)
+              commitAndGrantRoleParams[0].tokenAddress = AddressZero
+              await rolesRegistry
+                .connect(lender)
+                .commitTokens(lender.address, mockERC1155.address, tokenId, tokenAmount)
+              await expect(
+                marketplace.connect(lender).batchCommitTokensAndGrantRole(commitAndGrantRoleParams),
+              ).to.revertedWith("OriumSftMarketplace: tokenAddress provided does not match commitment's tokenAddress")
+            })
+            it('Should NOT commit tokens and grant role if tokenId does not match the commitment', async () => {
+              commitAndGrantRoleParams[0].commitmentId = BigNumber.from(1)
+              commitAndGrantRoleParams[0].tokenId = 0
+              await rolesRegistry
+                .connect(lender)
+                .commitTokens(lender.address, mockERC1155.address, tokenId, tokenAmount)
+              await expect(
+                marketplace.connect(lender).batchCommitTokensAndGrantRole(commitAndGrantRoleParams),
+              ).to.revertedWith("OriumSftMarketplace: tokenId provided does not match commitment's tokenId")
+            })
+            it('Should NOT commit tokens and grant role if tokenAmount does not match the commitment', async () => {
+              commitAndGrantRoleParams[0].commitmentId = BigNumber.from(1)
+              commitAndGrantRoleParams[0].tokenAmount = BigNumber.from(0)
+              await rolesRegistry
+                .connect(lender)
+                .commitTokens(lender.address, mockERC1155.address, tokenId, tokenAmount)
+              await expect(
+                marketplace.connect(lender).batchCommitTokensAndGrantRole(commitAndGrantRoleParams),
+              ).to.revertedWith("OriumSftMarketplace: tokenAmount provided does not match commitment's tokenAmount")
+            })
           })
         })
 
@@ -758,12 +819,34 @@ describe('OriumSftMarketplace', () => {
                 .to.emit(rolesRegistry, 'RoleRevoked')
                 .withArgs(1, UNIQUE_ROLE, borrower.address)
             })
+            it('Should NOT batch revoke role if contract is paused', async () => {
+              await marketplace.connect(operator).pause()
+              await expect(
+                marketplace
+                  .connect(lender)
+                  .batchRevokeRole([1], [UNIQUE_ROLE], [borrower.address], [mockERC1155.address]),
+              ).to.be.revertedWith('Pausable: paused')
+            })
             it("Should NOT batch revoke role if array's length are different", async () => {
               await expect(
                 marketplace
                   .connect(lender)
                   .batchRevokeRole([1], [UNIQUE_ROLE, UNIQUE_ROLE], [borrower.address], [mockERC1155.address]),
               ).to.be.revertedWith('OriumSftMarketplace: arrays length mismatch')
+            })
+            it("Should NOT batch revoke role if sender is not commitment's grantor", async () => {
+              await expect(
+                marketplace
+                  .connect(borrower)
+                  .batchRevokeRole([1], [UNIQUE_ROLE], [borrower.address], [mockERC1155.address]),
+              ).to.be.revertedWith("OriumSftMarketplace: sender is not the commitment's grantor")
+            })
+            it('Should NOT batch revoke role if tokenAddress does not match commitment', async () => {
+              await expect(
+                marketplace.connect(lender).batchRevokeRole([1], [UNIQUE_ROLE], [borrower.address], [AddressZero]),
+              ).to.be.revertedWith(
+                "OriumSftMarketplace: tokenAddress provided does not match commitment's tokenAddress",
+              )
             })
           })
         })

--- a/test/fixtures/OriumSftMarketplaceFixture.ts
+++ b/test/fixtures/OriumSftMarketplaceFixture.ts
@@ -40,9 +40,12 @@ export async function deploySftMarketplaceContracts() {
   const mockERC1155 = await MockERC1155Factory.deploy()
   await mockERC1155.deployed()
 
+  const secondMockERC1155 = await MockERC1155Factory.deploy()
+  await secondMockERC1155.deployed()
+
   const MockERC20Factory = await ethers.getContractFactory('MockERC20')
   const mockERC20 = await MockERC20Factory.deploy()
   await mockERC20.deployed()
 
-  return [marketplace, marketplaceRoyalties, rolesRegistry, mockERC1155, mockERC20] as Contract[]
+  return [marketplace, marketplaceRoyalties, rolesRegistry, mockERC1155, mockERC20, secondMockERC1155] as Contract[]
 }

--- a/utils/bignumber.ts
+++ b/utils/bignumber.ts
@@ -20,3 +20,12 @@ export function toWei(amount: string, decimals = 18) {
 export function fromWei(amount: BigNumber, decimals = 18) {
   return ethers.utils.formatUnits(amount, decimals)
 }
+
+/**
+ * @dev Converts ether per day to wei per second
+ * @param amount The amount of ether per day
+ * @returns The amount of wei per second
+ */
+export function etherPerDayToWeiPerSecond(amount: string) {
+  return toWei(amount).div(60 * 60 * 24)
+}

--- a/utils/roles.ts
+++ b/utils/roles.ts
@@ -2,3 +2,4 @@ import { ethers } from 'ethers'
 
 export const USER_ROLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('USER_ROLE'))
 export const UNIQUE_ROLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('UNIQUE_ROLE'))
+export const PLAYER_ROLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Player()'))


### PR DESCRIPTION
In some cases, the user can leverage the Marketplace's role approval to attempt to manage other users commitments. For this reason, access control was improved in the following functions:
* `batchCommitTokensAndGrantRole`: Checking if `commitmentId` passed matches other parameters (when `commitmentId != 0`).
* `batchRevokeRole`: Checking if sender is the grantor of the `commitmentId` passed, and if the commitment's `tokenAddress` macthes.

This PR also includes the following improvements:
* Included `whenNotPaused` modified on all external functions. This will be important to prevent users from accepting rental offers, creating direct rentals, and etc.
* Updated create offer script to easily calculate price in ether per day.
* Updated cancel offer script to fetch offer's details from subgraph.
* Function `endRental` does not need to copy all parameters to `memory` (changing to `calldata`).