### PR TITLE
Fix Marketplace Ownership Check

### DIFF
--- a/.openzeppelin/unknown-1284.json
+++ b/.openzeppelin/unknown-1284.json
@@ -574,6 +574,185 @@
         },
         "namespaces": {}
       }
+    },
+    "548be4a703b3592db89d0eb0678951c254742941488b36746bd669eec2cd9ca1": {
+      "address": "0xc4951f62E4f1df9fC411C6a9b752154FE6Bd0e0f",
+      "txHash": "0x1dc958c6a67034130a3aeddec499edfc33541346a14321686e7fe82c66701609",
+      "layout": {
+        "solcVersion": "0.8.9",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:40"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "oriumMarketplaceRoyalties",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "NftRentalMarketplace",
+            "src": "contracts/NftRentalMarketplace.sol:23"
+          },
+          {
+            "label": "isCreated",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "NftRentalMarketplace",
+            "src": "contracts/NftRentalMarketplace.sol:26"
+          },
+          {
+            "label": "nonceDeadline",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_uint64))",
+            "contract": "NftRentalMarketplace",
+            "src": "contracts/NftRentalMarketplace.sol:29"
+          },
+          {
+            "label": "roleDeadline",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_mapping(t_bytes32,t_mapping(t_address,t_mapping(t_uint256,t_uint64)))",
+            "contract": "NftRentalMarketplace",
+            "src": "contracts/NftRentalMarketplace.sol:32"
+          },
+          {
+            "label": "rentals",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_mapping(t_bytes32,t_struct(Rental)8615_storage)",
+            "contract": "NftRentalMarketplace",
+            "src": "contracts/NftRentalMarketplace.sol:35"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_uint64))": {
+            "label": "mapping(address => mapping(uint256 => uint64))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_mapping(t_address,t_mapping(t_uint256,t_uint64)))": {
+            "label": "mapping(bytes32 => mapping(address => mapping(uint256 => uint64)))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(Rental)8615_storage)": {
+            "label": "mapping(bytes32 => struct Rental)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint64)": {
+            "label": "mapping(uint256 => uint64)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Rental)8615_storage": {
+            "label": "struct Rental",
+            "members": [
+              {
+                "label": "borrower",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "expirationDate",
+                "type": "t_uint64",
+                "offset": 20,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
     }
   }
 }

--- a/addresses/moonbeam/index.json
+++ b/addresses/moonbeam/index.json
@@ -1,44 +1,42 @@
 {
-	"Multisig": {
-		"address": ""
-	},
-	"RolesRegistry": {
-		"address": ""
-	},
-	"SftRolesRegistrySingleRole": {
-		"address": ""
-	},
-	"KMSDeployer": {
-		"address": "0x04c8c6c56dab836f8bd62cb6884371507e706806"
-	},
-	"ImmutableOwnerCreate2Factory": {
-		"address": ""
-	},
-	"OriumMarketplaceRoyalties": {
-		"address": "0x1FdB03ee7e0A861D0495075C1459ef87bC4de54c",
-		"operator": "0x04c8c6c56dab836f8bd62cb6884371507e706806",
-		"implementation": "0xeE485138ae7b0A50F2342c67675c6D0a3bd1d3ea",
-		"proxyAdmin": "0xbee720D292d591cc94f522050cc2069070e3a15C"
-	},
-	"OriumSftMarketplace": {
-		"address": "",
-		"operator": "",
-		"implementation": "",
-		"proxyAdmin": "",
-		"libraries": [
-			""
-		]
-	},
-	"ERC7432WrapperForERC4907": {
-		"address": "0xc3154ccac181eb9d71ccd53f29f425bddd52d983"
-	},
-	"NftRentalMarketplace": {
-		"address": "0x201E1636BB21Dfd51F93815BCD008EAe2Fa29bD9",
-		"operator": "0x04c8c6c56dab836f8bd62cb6884371507e706806",
-		"implementation": "0x1112949A242A0283c2170b9F28931ccBE8878d18",
-		"proxyAdmin": "0x668e73cF24361cfE13801681d8885e6632A7Eaa6",
-		"libraries": {
-			"LibNftRentalMarketplace": "0x037c0ae89bAE6d86476074CE3ef4F235467B1B79"
-		}
-	}
+  "Multisig": {
+    "address": ""
+  },
+  "RolesRegistry": {
+    "address": ""
+  },
+  "SftRolesRegistrySingleRole": {
+    "address": ""
+  },
+  "KMSDeployer": {
+    "address": "0x04c8c6c56dab836f8bd62cb6884371507e706806"
+  },
+  "ImmutableOwnerCreate2Factory": {
+    "address": ""
+  },
+  "OriumMarketplaceRoyalties": {
+    "address": "0x1FdB03ee7e0A861D0495075C1459ef87bC4de54c",
+    "operator": "0x04c8c6c56dab836f8bd62cb6884371507e706806",
+    "implementation": "0xeE485138ae7b0A50F2342c67675c6D0a3bd1d3ea",
+    "proxyAdmin": "0xbee720D292d591cc94f522050cc2069070e3a15C"
+  },
+  "OriumSftMarketplace": {
+    "address": "",
+    "operator": "",
+    "implementation": "",
+    "proxyAdmin": "",
+    "libraries": [""]
+  },
+  "ERC7432WrapperForERC4907": {
+    "address": "0xc3154ccac181eb9d71ccd53f29f425bddd52d983"
+  },
+  "NftRentalMarketplace": {
+    "address": "0x201E1636BB21Dfd51F93815BCD008EAe2Fa29bD9",
+    "operator": "0x04c8c6c56dab836f8bd62cb6884371507e706806",
+    "implementation": "0xc4951f62E4f1df9fC411C6a9b752154FE6Bd0e0f",
+    "proxyAdmin": "0x668e73cF24361cfE13801681d8885e6632A7Eaa6",
+    "libraries": {
+      "LibNftRentalMarketplace": "0xD2f6956889241597b536C2E1Ae8d2E1052d17178"
+    }
+  }
 }

--- a/contracts/libraries/LibNftRentalMarketplace.sol
+++ b/contracts/libraries/LibNftRentalMarketplace.sol
@@ -53,13 +53,14 @@ library LibNftRentalMarketplace {
         address _rolesRegistry = IOriumMarketplaceRoyalties(_oriumMarketplaceRoyalties).nftRolesRegistryOf(
             _offer.tokenAddress
         );
-        address _nftOwner = IERC721(_offer.tokenAddress).ownerOf(_offer.tokenId);
+
+        // sender must be the ERC-721 or the ERC-7432 owner to create a rental offer
         require(
-            msg.sender == _nftOwner ||
-                (msg.sender == IERC7432(_rolesRegistry).ownerOf(_offer.tokenAddress, _offer.tokenId) &&
-                    _rolesRegistry == _nftOwner),
+            msg.sender == IERC721(_offer.tokenAddress).ownerOf(_offer.tokenId) ||
+                msg.sender == IERC7432(_rolesRegistry).ownerOf(_offer.tokenAddress, _offer.tokenId),
             'NftRentalMarketplace: only token owner can call this function'
         );
+
         require(
             IOriumMarketplaceRoyalties(_oriumMarketplaceRoyalties).isTrustedFeeTokenAddressForToken(
                 _offer.tokenAddress,
@@ -307,8 +308,7 @@ library LibNftRentalMarketplace {
             );
             require(
                 msg.sender == IERC721(_params[i].tokenAddress).ownerOf(_params[i].tokenId) ||
-                    msg.sender ==
-                    IERC7432(_rolesRegistry).ownerOf(_params[i].tokenAddress, _params[i].tokenId),
+                    msg.sender == IERC7432(_rolesRegistry).ownerOf(_params[i].tokenAddress, _params[i].tokenId),
                 'OriumNftMarketplace: sender is not the owner'
             );
 

--- a/scripts/nft-rental-marketplace/06-upgrade.ts
+++ b/scripts/nft-rental-marketplace/06-upgrade.ts
@@ -1,10 +1,8 @@
 import { print, colors } from '../../utils/misc'
 import { upgradeProxy } from '../../utils/upgrade-proxy'
 
-const CONTRACT_NAME = 'NftRentalMarketplace'
-
 async function main() {
-  await upgradeProxy(CONTRACT_NAME)
+  await upgradeProxy('NftRentalMarketplace', ['LibNftRentalMarketplace'])
 }
 
 main()


### PR DESCRIPTION
ERC-721 Marketplace was checking if the NFT was deposited in the roles registry in order to create the rental offer. However, GLMR Jungle NFTs use ERC-4907 and are deposited on another contract. Simply removing this check and ensuring the ERC-7432 `ownerOf` is used should be enough to check if sender owns the NFT.